### PR TITLE
Add support for multi-column --key values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Consider two CSV files:
       name: Pancakes
       age: 2
 
-The `--key=id` option means that the `id` column should be treated as the unique key, to identify which records have changed.
+The `--key=id` option means that the `id` column should be treated as the unique key, to identify which records have changed. To use a combination of columns as the key, separate them with a comma, e.g., `--key=id1,id2`.
 
 The tool will automatically detect if your files are comma- or tab-separated. You can over-ride this automatic detection and force the tool to use a specific format using `--format=tsv` or `--format=csv`.
 

--- a/csv_diff/__init__.py
+++ b/csv_diff/__init__.py
@@ -2,6 +2,7 @@ import csv
 from dictdiffer import diff
 import json
 import hashlib
+from operator import itemgetter
 
 
 def load_csv(fp, key=None, dialect=None):
@@ -18,7 +19,7 @@ def load_csv(fp, key=None, dialect=None):
     headings = next(fp)
     rows = [dict(zip(headings, line)) for line in fp]
     if key:
-        keyfn = lambda r: r[key]
+        keyfn = itemgetter(*key.split(","))
     else:
         keyfn = lambda r: hashlib.sha1(
             json.dumps(r, sort_keys=True).encode("utf8")
@@ -33,7 +34,7 @@ def load_json(fp, key=None):
     for item in raw_list:
         common_keys.update(item.keys())
     if key:
-        keyfn = lambda r: r[key]
+        keyfn = itemgetter(*key.split(","))
     else:
         keyfn = lambda r: hashlib.sha1(
             json.dumps(r, sort_keys=True).encode("utf8")

--- a/csv_diff/cli.py
+++ b/csv_diff/cli.py
@@ -14,7 +14,10 @@ from . import load_csv, load_json, compare, human_text
     type=click.Path(exists=True, file_okay=True, dir_okay=False, allow_dash=False),
 )
 @click.option(
-    "--key", type=str, default=None, help="Column to use as a unique ID for each row"
+    "--key",
+    type=str,
+    default=None,
+    help="Column(s) to use as a unique ID for each row. To use multiple keys, separate them with a comma, e.g., key1,key2",
 )
 @click.option(
     "--format",

--- a/tests/test_csv_diff.py
+++ b/tests/test_csv_diff.py
@@ -51,6 +51,20 @@ TEN = """id,name,age
 1,Cleo,5
 2,Pancakes,3"""
 
+ELEVEN = """state,county,pop
+CA,Yikes,100
+NY,Beep,200
+CA,Zoinks,100
+NY,Zoinks,200
+"""
+
+TWELVE = """state,county,pop
+CA,Yikes,100
+NY,Beep,200
+CA,Zoinks,300
+NY,Zoinks,200
+"""
+
 
 def test_row_changed():
     diff = compare(
@@ -112,6 +126,20 @@ def test_tsv():
         "added": [],
         "removed": [],
         "changed": [{"key": "1", "changes": {"age": ["4", "5"]}}],
+        "columns_added": [],
+        "columns_removed": [],
+    } == diff
+
+
+def test_multikey():
+    diff = compare(
+        load_csv(io.StringIO(ELEVEN), key="state,county"),
+        load_csv(io.StringIO(TWELVE), key="state,county"),
+    )
+    assert {
+        "added": [],
+        "removed": [],
+        "changed": [{"key": ("CA", "Zoinks"), "changes": {"pop": ["100", "300"]}}],
         "columns_added": [],
         "columns_removed": [],
     } == diff


### PR DESCRIPTION
These modifications allow users to pass multiple (comma-separated) columns as the `--key`, for scenarios in which rows are uniquely identified by a combination of columns — for instance, the county *and* the state. For instance:

```sh
csv-diff --key=state,county a.csv b.csv
```

An arbitrary number of columns can be used. These scenarios are fairly common, in my experience.

I aimed to make this implementation as simple as possible. As such, it doesn't handle one particular edge case: columns whose names *contain a comma*. My instinct is that this could be handled by adding a `--key-sep` option, in which the user could pass any arbitrary string to serve as a separator. E.g.,:

```sh
csv-diff --key="Column Name, With A Comma::Column 2" --key-sep="::" a.csv b.csv
```

... and then passing that argument to `load_csv`/`load_json`. But figured I'd raise the possibility here first before mucking around too much in the code.