### PR TITLE
build: Exclude tests from being recognized as package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author="Simon Willison",
     version=VERSION,
     license="Apache License, Version 2.0",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     install_requires=["click", "dictdiffer"],
     setup_requires=["pytest-runner"],
     extras_require={"test": ["pytest"]},


### PR DESCRIPTION
I maintain the AUR package of this tool: 

Today there was a bug report, that two packages have conflicting files, one beeing `python-csv-diff`:
https://aur.archlinux.org/packages/python-csv-diff#comment-896123

This change will in the future not package the `tests` directory, as it is not recognized as package anymore. I included this patch in the AUR package.

Thank you for the tool.