### PR TITLE
Added support for multi-keys on CSVs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv
 .DS_Store
 .schema
 .vscode
+build/*

--- a/csv_diff/__init__.py
+++ b/csv_diff/__init__.py
@@ -4,7 +4,7 @@ import json
 import hashlib
 
 
-def load_csv(fp, key=None, dialect=None):
+def load_csv(fp, key=None, dialect=None, key_sep='-'):
     if dialect is None and fp.seekable():
         # Peek at first 1MB to sniff the delimiter and other dialect details
         peek = fp.read(1024 ** 2)
@@ -18,7 +18,10 @@ def load_csv(fp, key=None, dialect=None):
     headings = next(fp)
     rows = [dict(zip(headings, line)) for line in fp]
     if key:
-        keyfn = lambda r: r[key]
+        if type(key) == list: # if a list of cols provided then build a concatenated key with them - order matters
+            keyfn = lambda r: key_sep.join([r[x] for x in key])
+        else:
+            keyfn = lambda r: r[key]
     else:
         keyfn = lambda r: hashlib.sha1(
             json.dumps(r, sort_keys=True).encode("utf8")

--- a/tests/test_csv_diff.py
+++ b/tests/test_csv_diff.py
@@ -51,6 +51,19 @@ TEN = """id,name,age
 1,Cleo,5
 2,Pancakes,3"""
 
+ELEVEN = """name, state, age
+Ann, UT, 56
+Ann, NY, 24
+Lisa, CA, 35
+Bill, FL, 33
+Bill, WY, 23"""
+
+TWELVE = """name, state, age
+Ann, UT, 45
+Ann, NY, 24
+Lisa, CA, 35
+Bill, WY, 23"""
+
 
 def test_row_changed():
     diff = compare(
@@ -114,4 +127,16 @@ def test_tsv():
         "changed": [{"key": "1", "changes": {"age": ["4", "5"]}}],
         "columns_added": [],
         "columns_removed": [],
+    } == diff
+
+def test_multi_key():
+    diff = compare(
+        load_csv(io.StringIO(ELEVEN), key=["name", "state"], key_sep='~'), load_csv(io.StringIO(TWELVE), key=["name", "state"], key_sep='~'), 
+    )
+    assert {
+        'added': [],
+        'removed': [{'name': 'Bill', 'state': 'FL', 'age': '33'}],
+        'changed': [{'key': 'Ann~UT', 'changes': {'age': ['56', '45']}}],
+        'columns_added': [],
+        'columns_removed': [],
     } == diff


### PR DESCRIPTION
I've added support to use multiple keys on CSVs for the comparison.
If the provide key is a list of column names instead of a single column name, the code kicks in to create a concatenated key comprised of the provided columns. An optional key separator can be provided to affect comparison text displays. 