### PR TITLE
skip blank rows in load_csv, closes #29

### DIFF
--- a/csv_diff/__init__.py
+++ b/csv_diff/__init__.py
@@ -16,7 +16,12 @@ def load_csv(fp, key=None, dialect=None):
             pass
     fp = csv.reader(fp, dialect=(dialect or "excel"))
     headings = next(fp)
-    rows = [dict(zip(headings, line)) for line in fp]
+    # Skip blank rows so trailing newlines (or stray blank lines inside the
+    # file) don't get treated as data rows that are missing every column -
+    # that surfaced as an unhelpful KeyError on the key column. A row is
+    # "blank" if csv.reader returned no fields for it, which is what happens
+    # when the final record is just "\n" or a file ends with extra blank lines.
+    rows = [dict(zip(headings, line)) for line in fp if line]
     if key:
         keyfn = lambda r: r[key]
     else:

--- a/tests/test_csv_diff.py
+++ b/tests/test_csv_diff.py
@@ -51,6 +51,22 @@ TEN = """id,name,age
 1,Cleo,5
 2,Pancakes,3"""
 
+# Trailing blank line - the most common case (POSIX text files end in \n,
+# many editors add an extra one). Used to raise KeyError on the key column.
+SEVEN_TRAILING = """id,name,age
+1,Cleo,4
+2,Pancakes,2
+"""
+
+# Multiple trailing blank lines, plus a blank row in the middle of the file.
+EIGHT_BLANK = """id,name,age
+
+1,Cleo,4
+2,Pancakes,2
+
+
+"""
+
 
 def test_row_changed():
     diff = compare(
@@ -115,3 +131,41 @@ def test_tsv():
         "columns_added": [],
         "columns_removed": [],
     } == diff
+
+
+def test_trailing_blank_line_is_skipped():
+    # https://github.com/simonw/csv-diff/issues/29 - a file ending in "\n"
+    # (or any number of empty trailing lines) used to produce a dict entry
+    # missing every column, which then KeyError'd on the key column. The
+    # loader should silently skip blank rows so the rest of the diff runs.
+    loaded = load_csv(io.StringIO(SEVEN_TRAILING), key="id")
+    assert loaded == {
+        "1": {"id": "1", "name": "Cleo", "age": "4"},
+        "2": {"id": "2", "name": "Pancakes", "age": "2"},
+    }
+
+
+def test_multiple_blank_lines_and_interior_blank_skipped():
+    # A blank row in the middle and several trailing blank lines should all
+    # be dropped - the loader treats csv.reader's empty `line` as the marker
+    # of a row that contributed no fields.
+    loaded = load_csv(io.StringIO(EIGHT_BLANK), key="id")
+    assert loaded == {
+        "1": {"id": "1", "name": "Cleo", "age": "4"},
+        "2": {"id": "2", "name": "Pancakes", "age": "2"},
+    }
+
+
+def test_compare_with_trailing_blank_lines():
+    # End-to-end: comparing two identical files where both have a trailing
+    # newline should report no changes (regression check for issue #29).
+    a = "id,name,age\n1,Cleo,4\n"
+    b = "id,name,age\n1,Cleo,4\n"
+    diff = compare(load_csv(io.StringIO(a), key="id"), load_csv(io.StringIO(b), key="id"))
+    assert diff == {
+        "added": [],
+        "removed": [],
+        "changed": [],
+        "columns_added": [],
+        "columns_removed": [],
+    }


### PR DESCRIPTION
Closes #29.

A file ending with `\n` (or any number of blank trailing lines) used to produce a dict entry that was missing every column, which then crashed with `KeyError: 'a'` (or whichever key column was passed) when the caller tried to look up the key. The error message gave no hint that the actual problem was a stray blank line at the end of the file.

`csv.reader` returns an empty list for a fully blank row (a record of just `\n`), so filtering those out before building the dicts is enough - blank rows in the middle of the file are skipped the same way. Whitespace-only and comma-only lines still parse as data rows, which preserves the existing behaviour for inputs where those carry meaning (e.g. a row of `,` is a row with two empty fields, not a blank row).

### Reproduce

Before:
```
$ printf "a,b,c\n1,2,3\n\n" > /tmp/a.csv
$ csv-diff /tmp/a.csv /tmp/a.csv --key a
KeyError: 'a'
```

After:
```
$ csv-diff /tmp/a.csv /tmp/a.csv --key a
$ # exits 0, no output (the two files diff to themselves)
```

### Tests added

`tests/test_csv_diff.py`:
- `test_trailing_blank_line_is_skipped`: loads a CSV with a single trailing blank line and asserts the key lookup no longer raises and the loaded rows are correct.
- `test_multiple_blank_lines_and_interior_blank_skipped`: loads a CSV with several trailing blank lines plus a blank line in the middle, asserts the rows dict is identical to the same data without the blank lines.
- `test_compare_with_trailing_blank_lines`: runs `compare()` against two CSVs that both end in blank lines and asserts the diff result is equivalent to comparing the same data without the blank lines.

All 27 tests pass (24 existing + 3 new).